### PR TITLE
Fix language publishing command

### DIFF
--- a/src/FilamentUsersServiceProvider.php
+++ b/src/FilamentUsersServiceProvider.php
@@ -28,7 +28,7 @@ class FilamentUsersServiceProvider extends ServiceProvider
         //Publish Lang
         $this->publishes([
             __DIR__ . '/../resources/lang' => app_path('lang/vendor/filament-users'),
-        ], 'filament-users');
+        ], 'filament-users-lang');
     }
 
     public function boot(): void


### PR DESCRIPTION
Change 'filament-users' to 'filament-users-lang' on line 31 of FilamentUsersServiceProvider so the command matches the documentation.