### PR TITLE
fix: user edit

### DIFF
--- a/src/Resources/UserResource.php
+++ b/src/Resources/UserResource.php
@@ -67,10 +67,10 @@ class UserResource extends Resource
                 ->label(trans('filament-users::user.resource.password'))
                 ->password()
                 ->maxLength(255)
-                ->dehydrateStateUsing(static function ($state) use ($form) {
+                ->dehydrateStateUsing(static function ($state, $record) use ($form) {
                     return !empty($state)
                         ? Hash::make($state)
-                        : User::find($form->getColumns())?->password;
+                        : $record->password;
                 }),
         ];
 


### PR DESCRIPTION
Editing a user without changing their password would fail with the error "Property [password] does not exist on this collection instance". This change uses the `$record` for the user as provided by filament instead of fetching the user based on form input data, since the user will never be found if you search for it in the DB by the new name which was not yet persisted.

Partially resolves #4