### PR TITLE
fix Property [password] does not exist on this collection instance. (closes #4)

### DIFF
--- a/src/Resources/UserResource.php
+++ b/src/Resources/UserResource.php
@@ -67,10 +67,10 @@ class UserResource extends Resource
                 ->label(trans('filament-users::user.resource.password'))
                 ->password()
                 ->maxLength(255)
-                ->dehydrateStateUsing(static function ($state) use ($form) {
+                ->dehydrateStateUsing(static function ($state, $record) {
                     return !empty($state)
                         ? Hash::make($state)
-                        : User::find($form->getColumns())?->password;
+                        : $record?->password;
                 }),
         ];
 


### PR DESCRIPTION
Previously the plugin tried to get the user instance via 
```php
User::find($form->getColumns)?->password
```

but `$form->getColumns` does not return the user or the user id instead it returns an array with defined columns, for example `[lg => 2]` which ultimately results in returning a collection of a single user with the id of 2.

Obviously this is not what we want. So with this PR it returns the password if exists.