### PR TITLE
docs: Added publish assets command after Filament Shield install

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Now run the following command to install shield:
 php artisan shield:install
 ```
 
+Now we can [publish the package assets]([https://github.com/bezhanSalleh/filament-shield](https://github.com/tomatophp/filament-users?tab=readme-ov-file#publish-assets)).
+```bash
+php artisan vendor:publish --tag="filament-users-config"
+```
 now on your `filament-users.php` config allow shield
 
 ```php


### PR DESCRIPTION
Add the missing step to publish the assets after installing Filament Shield.

Related with issue #8 

