### PR TITLE
Password is '' after editing user.

### DIFF
--- a/src/Resources/UserResource/Form/Components/Password.php
+++ b/src/Resources/UserResource/Form/Components/Password.php
@@ -19,6 +19,7 @@ class Password extends Component
             ->revealable(filament()->arePasswordsRevealable())
             ->required(fn ($record) => ! $record)
             ->rule(\Illuminate\Validation\Rules\Password::default())
+            ->dehydrated(fn ($state) => filled($state))
             ->dehydrateStateUsing(fn ($state) => Hash::make($state))
             ->same('passwordConfirmation')
             ->validationAttribute(__('filament-panels::pages/auth/register.form.password.validation_attribute'));


### PR DESCRIPTION
I encountered this bug when adding a role to a User. If we take a look at the update form, the password fields are not required. My assumption is that it should be possible for a admin to change a User, without changing the password.
But now on updating a User, the password field get submitted aswel. So the User will end up with '' as password.

I found [this](https://v2.filamentphp.com/tricks/password-form-fields) solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced password handling with a new condition to determine when the password field should be dehydrated based on its state.

- **Bug Fixes**
	- Improved logic for password field management, ensuring better validation based on user input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->