### PR TITLE
Add user language translations for pt_PT locale

### DIFF
--- a/resources/lang/pt_PT/user.php
+++ b/resources/lang/pt_PT/user.php
@@ -1,0 +1,38 @@
+<?php
+
+return [
+    'group' => 'ALC',
+    'resource' => [
+        'id' => 'ID',
+        'single' => 'Utilizador',
+        'email_verified_at' => 'Email Verificado em',
+        'created_at' => 'Criado em',
+        'updated_at' => 'Atualizado em',
+        'verified' => 'Verificado',
+        'unverified' => 'Não verificado',
+        'name' => 'Nome',
+        'email' => 'Email',
+        'password' => 'Palavra-passe',
+        'roles' => 'Funções',
+        'label' => 'Utilizadores',
+        'title' => [
+            'show' => 'Ver Utilizador',
+            'delete' => 'Apagar Utilizador',
+            'impersonate' => 'Simular Utilizador',
+            'create' => 'Criar Utilizador',
+            'edit' => 'Editar Utilizador',
+            'list' => 'Utilizadores',
+            'home' => 'Utilizadores',
+        ],
+        'notificaitons' => [
+            'last' => [
+                'title' => 'Erro',
+                'body' => 'Não é possível apagar o último utilizador',
+            ],
+            'self' => [
+                'title' => 'Erro',
+                'body' => 'Não pode apagar-se a si mesmo',
+            ],
+        ],
+    ],
+];


### PR DESCRIPTION
Introduce Portuguese translations for user-related terms and actions, including user creation, editing, and notification messages. This addition improves localization support, allowing users to interact with the application in Portuguese.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced localization support for user-related functionalities in Portuguese, enhancing accessibility for Portuguese-speaking users.
	- Added various user action labels and notification messages for improved user experience during interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->