### PR TITLE
Update FilamentUsersServiceProvider.php

### DIFF
--- a/src/FilamentUsersServiceProvider.php
+++ b/src/FilamentUsersServiceProvider.php
@@ -27,7 +27,7 @@ class FilamentUsersServiceProvider extends ServiceProvider
 
         //Publish Lang
         $this->publishes([
-            __DIR__ . '/../resources/lang' => app_path('lang/vendor/filament-users'),
+            __DIR__ . '/../resources/lang' => base_path('lang/vendor/filament-users'),
         ], 'filament-users-lang');
 
         $this->app->bind('filament-user', function () {


### PR DESCRIPTION
Fix publishing translations. 

Currently it publish translations to `app/lang/vendor/filament-users`

It is wrong location. Correct on should be `lang/vendor/filament-users`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the location for language file publishing to streamline and standardize localization resource management for easier customization by users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->