### PR TITLE
Corrected case on UserInfolist reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ you can customize all resource classes to be any class you want with the same re
         'class' => \TomatoPHP\FilamentUsers\Resources\UserResource\Form\UserForm::class
     ],
     'infolist' => [
-        'class' => \TomatoPHP\FilamentUsers\Resources\UserResource\InfoList\UserInfoList::class
+        'class' => \TomatoPHP\FilamentUsers\Resources\UserResource\InfoList\UserInfolist::class
     ]
 ]
 ```

--- a/src/FilamentUsersPlugin.php
+++ b/src/FilamentUsersPlugin.php
@@ -78,7 +78,7 @@ class FilamentUsersPlugin implements Plugin
             Users\Tables\UsersTable::register(Users\Tables\Columns\Roles::make());
             Users\Tables\UserFilters::register(Users\Tables\Filters\Roles::make());
             Users\Tables\UserBulkActions::register(Users\Tables\BulkActions\RolesAction::make());
-            Users\Schemas\UserInfoList::register(Users\Schemas\Entries\Roles::make());
+            Users\Schemas\UserInfolist::register(Users\Schemas\Entries\Roles::make());
         }
 
         if (config('filament-users.teams') && class_exists(\Laravel\Jetstream\Team::class)) {
@@ -86,7 +86,7 @@ class FilamentUsersPlugin implements Plugin
             Users\Tables\UsersTable::register(Users\Tables\Columns\Teams::make());
             Users\Tables\UserFilters::register(Users\Tables\Filters\Teams::make());
             Users\Tables\UserBulkActions::register(Users\Tables\BulkActions\TeamsAction::make());
-            Users\Schemas\UserInfoList::register(Users\Schemas\Entries\Teams::make());
+            Users\Schemas\UserInfolist::register(Users\Schemas\Entries\Teams::make());
         }
 
         if (config('filament-users.impersonate.enabled')) {


### PR DESCRIPTION
Upgrading to v4 causes an error in case sensitive OS

Error: Class "TomatoPHP\FilamentUsers\Filament\Resources\Users\Schemas\UserInfoList" not found

Due to the name change of UserInfoList to UserInfolist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a class name to ensure proper registration of Roles and Teams in user schemas.
  * Fixed class name casing in documentation for resource customization examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->