### PR TITLE
fix: prevent double password hashing with Laravel 11+ hashed cast

### DIFF
--- a/src/Filament/Resources/Users/Schemas/Components/Password.php
+++ b/src/Filament/Resources/Users/Schemas/Components/Password.php
@@ -6,7 +6,6 @@ namespace TomatoPHP\FilamentUsers\Filament\Resources\Users\Schemas\Components;
 
 use Filament\Forms;
 use Filament\Forms\Components\TextInput;
-use Illuminate\Support\Facades\Hash;
 
 class Password extends Component
 {
@@ -23,7 +22,6 @@ class Password extends Component
             ->required(static fn ($record) => ! $record)
             ->rule(\Illuminate\Validation\Rules\Password::default())
             ->dehydrated(static fn ($state) => filled($state))
-            ->dehydrateStateUsing(Hash::make(...))
             ->same('passwordConfirmation')
             ->validationAttribute(__('filament-panels::pages/auth/register.form.password.validation_attribute'));
     }

--- a/src/Filament/Resources/Users/Tables/Actions/ChangePassword.php
+++ b/src/Filament/Resources/Users/Tables/Actions/ChangePassword.php
@@ -7,7 +7,6 @@ namespace TomatoPHP\FilamentUsers\Filament\Resources\Users\Tables\Actions;
 use Filament\Actions;
 use Filament\Forms;
 use Filament\Notifications\Notification;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 class ChangePassword extends Action
@@ -30,7 +29,6 @@ class ChangePassword extends Action
                     ->required(static fn ($record) => ! $record)
                     ->rule(\Illuminate\Validation\Rules\Password::default())
                     ->dehydrated(filled(...))
-                    ->dehydrateStateUsing(Hash::make(...))
                     ->same('passwordConfirmation'),
                 Forms\Components\TextInput::make('passwordConfirmation')
                     ->label(trans('filament-users::user.resource.password_confirmation'))


### PR DESCRIPTION
The package was hashing passwords via `dehydrateStateUsing(Hash::make(...))` 
in form components. When used with Laravel 11+ where the User model has 
the default `'password' => 'hashed'` cast, passwords were being hashed 
twice, making authentication impossible.

Changes:
- Remove dehydrateStateUsing from Password component
- Remove dehydrateStateUsing from ChangePassword action
- Remove unused Hash facade imports

The model should be responsible for password hashing, not the form components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated password field handling in user management components for improved code organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->