### PR TITLE
Fix password change action with given password

### DIFF
--- a/src/Filament/Resources/Users/Tables/Actions/ChangePassword.php
+++ b/src/Filament/Resources/Users/Tables/Actions/ChangePassword.php
@@ -42,7 +42,7 @@ class ChangePassword extends Action
             ->action(static function ($record, $data) {
                 $auto = ! isset($data['password']);
                 $password = $data['password'] ?? Str::random(12);
-                $record->password = $password;
+                $record->password = Hash::make($password);
                 $record->save();
 
                 Notification::make()

--- a/src/Filament/Resources/Users/Tables/Actions/ChangePassword.php
+++ b/src/Filament/Resources/Users/Tables/Actions/ChangePassword.php
@@ -29,8 +29,7 @@ class ChangePassword extends Action
                     ->revealable(filament()->arePasswordsRevealable())
                     ->required(static fn ($record) => ! $record)
                     ->rule(\Illuminate\Validation\Rules\Password::default())
-                    ->dehydrated(filled(...))
-                    ->dehydrateStateUsing(Hash::make(...))
+                    ->dehydrated(fn ($state) => filled($state))
                     ->same('passwordConfirmation'),
                 Forms\Components\TextInput::make('passwordConfirmation')
                     ->label(trans('filament-users::user.resource.password_confirmation'))


### PR DESCRIPTION
Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Passwords are now reliably hashed when saved from the change-password action to ensure secure storage.
* **Refactor**
  * Simplified how the password change form processes field values during submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->